### PR TITLE
add Browser auto-launch for Linux

### DIFF
--- a/src/inspector.py
+++ b/src/inspector.py
@@ -117,6 +117,9 @@ def start():
     # in privileged mode.
     if os_platform == 'windows':
         utils.open_browser_on_windows('{0}/user/{1}'.format(server_config.BASE_URL, pretty_user_key))
+    elif os_platform == 'linux':
+        utils.open_browser_on_linux('{0}/user/{1}'.format(server_config.BASE_URL, pretty_user_key))
+
 
     return state
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -354,3 +354,12 @@ def open_browser_on_windows(url):
         subprocess.call(['start', '', url], shell=True)    
     except Exception:
         pass
+
+def open_browser_on_linux(url):
+
+    try:
+        logname = subprocess.check_output(['logname']).rstrip().decode('utf-8')
+        subprocess.call(['sudo', '-u', logname, 'sensible-browser', url])
+
+    except Exception:
+        pass


### PR DESCRIPTION
Adding methods to <code>inspector.py</code> and <code>utils.py</code> to enable auto-launch of the default browser on a Linux system. 

The feature is accomplished by running the web browser evoking sub-process without root privilege. First, the method I added first collects <code>logname</code> from the system, then uses the <code>logname</code> to run a non-root sub-process.

This feature has been tested successfully on Ubuntu 20.04. In theory, it will work all Debian derived Linux distribution. 