### PR TITLE
Fixed OSError: Open too many files on macOSX

### DIFF
--- a/src/inspector.py
+++ b/src/inspector.py
@@ -5,7 +5,6 @@ Entry point for Inspector UI.
 import logging
 import subprocess
 import sys
-import webbrowser
 
 from arp_scan import ArpScan
 from arp_spoof import ArpSpoof
@@ -126,13 +125,7 @@ def start():
 
     if os_platform == 'windows' or 'mac':
         url = '{0}/user/{1}'.format(server_config.BASE_URL, pretty_user_key)
-        try:
-            try:
-                webbrowser.get('chrome').open(url, new=2)
-            except webbrowser.Error:
-                webbrowser.open(url, new=2)
-        except Exception:
-            pass
+        utils.open_browser(url)
     return state
 
 

--- a/src/netdisco_wrapper.py
+++ b/src/netdisco_wrapper.py
@@ -70,10 +70,12 @@ class NetdiscoWrapper(object):
             # Get device_id based on MAC
             device_id = utils.get_device_id(device_mac, self._host_state)
 
-            # Submit for upload lter
+            # Submit for upload later
             with self._host_state.lock:
                 self._host_state.pending_netdisco_dict \
                     .setdefault(device_id, []).append(device_info)
+
+        netdis.stop()
 
 def test():
     n = NetdiscoWrapper(None)

--- a/src/start_inspector.py
+++ b/src/start_inspector.py
@@ -32,14 +32,14 @@ def main():
         if not os.path.exists(npcap_path):
             sys.stderr.write("IoT Inspector cannot run without installing Npcap.\n")
             sys.stderr.write("For details, visit " + server_config.NPCAP_ERROR_URL)
-            utils.open_browser_on_windows(server_config.NPCAP_ERROR_URL)
+            utils.open_browser(server_config.NPCAP_ERROR_URL)
             sys.exit(1)
 
         # Check presence of multiple interfaces (e.g., VPN)
         if len(utils.get_network_ip_range()) == 0:
             sys.stderr.write("IoT Inspector cannot run with multiple network interfaces running.\n")
             sys.stderr.write("For details, visit " + server_config.NETMASK_ERROR_URL)
-            utils.open_browser_on_windows(server_config.NETMASK_ERROR_URL)
+            utils.open_browser(server_config.NETMASK_ERROR_URL)
             sys.exit(1)
 
     utils.log('[Main] Terminating existing processes.')

--- a/src/utils.py
+++ b/src/utils.py
@@ -19,6 +19,7 @@ import threading
 import time
 import traceback
 import uuid
+import webbrowser
 
 import server_config
 
@@ -350,9 +351,11 @@ def get_os():
     raise RuntimeError('Unsupported operating system.')
 
 
-def open_browser_on_windows(url):
-
+def open_browser(url):
     try:
-        subprocess.call(['start', '', url], shell=True)    
+        try:
+            webbrowser.get('chrome').open(url, new=2)
+        except webbrowser.Error:
+            webbrowser.open(url, new=2)
     except Exception:
         pass


### PR DESCRIPTION
Two changes:
1. Fixed the issue at #110 . `netdisco` previously did not properly close the open scanners so `netdisco` continuously open new sockets until the limit. A socket is a type of `fd` in `mac`, which caused this error on macOSX. Using `ulimit -Sn` does not work. See this [post](https://stackoverflow.com/questions/7695701/filedescriptor-out-of-range-in-select-when-using-pythons-subprocess-with-rs).

Testing: 
```python3
from netdisco.discovery import NetworkDiscovery
for _ in range(5000):
    netdis = NetworkDiscovery()
    netdis.scan()
    netdis.discover()
    netdis.stop() # without this line, you can reproduce the OSError on macOS
```
2. Cleaned up the opening browser tab feature