### PR TITLE
Added check to only process ARP packets from the same network

### DIFF
--- a/src/host_state.py
+++ b/src/host_state.py
@@ -20,6 +20,8 @@ class HostState(object):
         self.host_ip = None
         self.host_mac = None
         self.gateway_ip = None
+        self.net = None
+        self.mask = None
         self.packet_processor = None
         self.user_key = None
         self.secret_salt = None

--- a/src/inspector.py
+++ b/src/inspector.py
@@ -60,6 +60,7 @@ def start():
     state.secret_salt = config_dict['secret_salt']
     state.host_mac = utils.get_my_mac()
     state.gateway_ip, _, state.host_ip = utils.get_default_route()
+    state.net, state.mask = utils.get_net_and_mask()
 
     # Read special command-line arguments
     if '--raspberry_pi_mode' in sys.argv:

--- a/src/packet_processor.py
+++ b/src/packet_processor.py
@@ -94,7 +94,9 @@ class PacketProcessor(object):
             # address turns out to be already in use by another host.
             # An ARP Probe conveys both a question ("Is anyone using this address?") and an
             # implied statement ("This is the address I hope to use.").
-            if pkt.op == 1 or pkt.op == 2 and pkt.hwsrc != self._host_state.host_mac and pkt.psrc != "0.0.0.0":
+            if (pkt.op == 1 or pkt.op == 2 and pkt.hwsrc != self._host_state.host_mac and
+                pkt.psrc != "0.0.0.0" and
+                utils.check_pkt_in_network(pkt.psrc, self._host_state.net, self._host_state.mask)):
                 self._host_state.set_ip_mac_mapping(pkt.psrc, pkt.hwsrc)
 
         except AttributeError:

--- a/src/utils.py
+++ b/src/utils.py
@@ -21,6 +21,7 @@ import time
 import traceback
 import uuid
 import webbrowser
+import ipaddress
 
 import server_config
 
@@ -170,6 +171,23 @@ def get_default_route():
                 routes[i] = (*route[:-1], 0)
 
     return default_route
+
+
+def get_net_and_mask():
+    iface = get_default_route()[1]
+    routes = _get_routes()
+    net = mask = None
+    for route in routes:
+        if route[3] == iface:
+            net = ipaddress.IPv4Address(route[0])
+            mask = ipaddress.IPv4Address(route[1])
+            break
+    return net, mask
+
+
+def check_pkt_in_network(ip, net, mask):
+    full_net = ipaddress.ip_network(f"{ip}/{mask}", strict=False)
+    return full_net.network_address == net
 
 
 def get_network_ip_range_windows():


### PR DESCRIPTION
We should not update our ARP table based on ARP packets coming from the network other than IoT-Inspector's network.