### PR TITLE
Update deprecated streamlit APIs

### DIFF
--- a/ui/Device_List.py
+++ b/ui/Device_List.py
@@ -342,5 +342,5 @@ if auto_refresh:
     # Auto-refresh
     if 'page_auto_refresh' in st.session_state and st.session_state['page_auto_refresh']:
         time.sleep(2)
-        st.experimental_rerun()
+        st.rerun()
 

--- a/ui/consent.py
+++ b/ui/consent.py
@@ -30,7 +30,7 @@ def show_overall_risks():
     consent = st.button('I accept the risks.', type='primary')
     if consent:
         config.set('has_consented_to_overall_risks', True)
-        st.experimental_rerun()
+        st.rerun()
 
     # Show a secondary button to reject the consent and quit
     reject = st.button('I do not accept the risks. I would like to quit IoT Inspector.', type='secondary')

--- a/ui/pages/1_Overview.py
+++ b/ui/pages/1_Overview.py
@@ -365,6 +365,6 @@ main()
 # Auto-refresh
 if 'page_auto_refresh' in st.session_state and st.session_state['page_auto_refresh']:
     time.sleep(4)
-    st.experimental_rerun()
+    st.rerun()
 
 

--- a/ui/pages/2_Device_Details.py
+++ b/ui/pages/2_Device_Details.py
@@ -400,9 +400,8 @@ pre_selected_index = 0
 default_option = '(Select a device below)'
 device_list = [default_option] + get_device_list()
 
-query_params = st.experimental_get_query_params()
-if 'mac_addr' in query_params:
-    mac_addr = query_params['mac_addr'][0]
+if 'mac_addr' in st.query_params:
+    mac_addr = st.query_params['mac_addr'][0]
     for (ix, device_description) in enumerate(device_list):
         if mac_addr in device_description:
             pre_selected_index = ix
@@ -429,6 +428,6 @@ with st.empty():
 # Auto-refresh
 if 'page_auto_refresh' in st.session_state and st.session_state['page_auto_refresh']:
     time.sleep(4)
-    st.experimental_rerun()
+    st.rerun()
 
 

--- a/ui/survey.py
+++ b/ui/survey.py
@@ -85,7 +85,7 @@ def show_survey_text(qualtrics_id):
                 for _ in range(100):
                     st.markdown('')
                 time.sleep(5)
-                st.experimental_rerun()
+                st.rerun()
 
             for _ in range(10):
                 st.markdown('')


### PR DESCRIPTION
It seems that the `streamlit` library (used in the UI) has [deprecated](https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/__init__.py#L286) `experimental_get_query_params()`. When running on OSX, you actually see this message in the UI:

<img width="612" alt="Screenshot 2025-04-06 at 12 28 00" src="https://github.com/user-attachments/assets/b2736a5e-cb50-4cd6-90fe-487f997216bd" />

Furthermore, it also seems that `experimental_rerun()` has been [renamed](https://github.com/streamlit/streamlit/blob/develop/lib/streamlit/commands/execution_control.py#L105) to `rerun()`. This also shows an error in the UI:

<img width="887" alt="Screenshot 2025-04-06 at 12 36 46" src="https://github.com/user-attachments/assets/13aa0f0c-ea17-42ab-8d42-bd57bc039664" />

This PR just updates the UI to use the correct `streamlit` API interface.


