### PR TITLE
Add Wheel creation and CI/CD

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_general.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_general.md
@@ -1,0 +1,25 @@
+---
+name: Bug report - Other bugs
+about: Create a report to help us improve
+
+---
+
+<!-- This template is meant for GENERAL bug reports.
+
+Please be as descriptive as possible
+-->
+
+### Expected behavior
+
+### Actual behavior
+
+### Steps to reproduce the behavior
+
+- Use code markdown `CODE` to make your code visible
+
+<!-- ADDITIONAL CONTEXT -->
+
+### Additional Logs, screenshots, source code,  configuration dump, ...
+
+Drag and drop zip archives containing the Additional info here, don't use external services or link.
+Screenshots can be directly dropped here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+### Feature
+
+- [ ] New functionality with network package processing for IoT traffic
+- [ ] UI/UX improvements
+- [ ] Performance enhancements
+- [ ] Other (elaborated below)
+
+**Describe the feature you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+ <!-- Filling this template is mandatory -->
+
+**Your checklist for this pull request**
+- [ ] I've documented or updated the documentation of every function this PR changes
+- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
+
+**Detailed description**
+
+<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
+
+...
+
+**Test plan**
+
+<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. -->
+
+...
+
+**Closing issues**
+
+<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
+
+...

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,20 @@
+Documentation:
+  - '**/*.md'
+
+Github-files:
+  - '.github/**'
+
+Tests:
+  - 'tests/**'
+
+Analysis:
+  - 'analysis/**'
+
+Core:
+  - 'core/**'
+
+Data:
+  - 'data/**'
+
+UI:
+  - 'ui/**'

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,75 @@
+name: Publish Wheel package to PyPI
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    outputs:
+      v-version: ${{ steps.version.outputs.v-version }}
+    steps:
+      - name: Get next version
+        uses: reecetech/version-increment@2024.10.1
+        id: version
+        with:
+          release_branch: master
+          use_api: true
+          increment: minor
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [create_release]
+    steps:
+    - name: Checkout project sources
+      uses: actions/checkout@v4
+
+    - name: Create wheel file
+      run: |
+        python3 -m pip install --upgrade pip
+        python3 -m pip install setuptools wheel build setuptools_scm
+        PRETEND_VERSION=${{ needs.create_release.outputs.v-version }} python3 -m build --wheel .
+
+    - name: Store the IoT Inspector Python wheel
+      uses: actions/upload-artifact@v4
+      with:
+        name: iot-inspector
+        path: dist/iot-inspector*.whl
+        if-no-files-found: error
+
+  publish-to-pypi:
+    name: Publish Python 🐍 distribution 📦 to PyPI
+    if: false
+    # if: github.repository == 'nyu-mlab/iot-inspector-client'
+    needs: [create_release, build]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/iot-inspector  # Replace <package-name> with your PyPI project name
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+      contents: write  # Required for creating releases
+
+    steps:
+      - name: Download all the wheel file
+        uses: actions/download-artifact@v4
+        with:
+          name: iot-inspector
+          path: dist/
+
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+
+      - name: Upload wheel and debian packages to release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.create_release.outputs.v-version }}
+          files: |
+            dist/iot-inspector*.whl

--- a/.github/workflows/inspector_test.yaml
+++ b/.github/workflows/inspector_test.yaml
@@ -1,0 +1,43 @@
+name: libinspector_test
+
+on:
+  workflow_dispatch:
+  pull_request:
+# Run every 30 days, just to confirm that the code is still working
+  schedule:
+    - cron: '0 0 */30 * *'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+
+    steps:
+    - name: Checkout project sources
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest coverage ruff
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    # https://github.com/astral-sh/ruff
+    - name: Lint with ruff
+      run: |
+        ruff check
+    #- name: Test with pytest and obtain code coverage
+    #  run: |
+    #    coverage run -m pytest src/tests
+    #- name: Upload coverage reports to Codecov
+    #  uses: codecov/codecov-action@v4
+    #  with:
+    #    token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,20 @@
+name: Pull Request Labeler
+on:
+  - pull_request_target
+
+# Automatically cancel any previous workflow on a new push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/labeler@v4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 .*
+!.github/
 user-data*
 3rd-party-software
 *.zip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["setuptools>=64", "wheel", "setuptools-scm>=8"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = [
+    "analysis",
+    "analysis.*",
+    "core",
+    "core.*",
+    "ui",
+    "ui.*",
+    "data",
+    "data.*",
+]
+
+[project]
+name = "iot-inspector"
+dynamic = ["version"]
+description = "IoT Inspector Client for analyzing IoT device firmware"
+readme = "README.md"
+authors = [
+    { name = "Danny Huang", email = "dhuang@nyu.edu" }
+]
+requires-python = ">=3.10"
+dependencies = [
+    "pandas",
+    "peewee",
+    "scapy",
+    "requests",
+    "geoip2",
+    "netifaces",
+    "netaddr",
+    "streamlit",
+    "plotly",
+    "tldextract",
+    "kaleido"
+]
+license = "MIT"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+[project.urls]
+Homepage = "https://inspector.engineering.nyu.edu/"
+Source = "https://github.com/nyu-mlab/iot-inspector-client/"
+Tracker = "https://github.com/nyu-mlab/iot-inspector-client/issues"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+import setuptools
+import os
+
+if "PRETEND_VERSION" in os.environ:
+    version = os.environ["PRETEND_VERSION"]
+else:
+    from setuptools_scm import get_version
+    version = get_version(root='.',
+                          fallback_version="0.0.1",
+                          version_scheme="guess-next-dev",
+                          local_scheme="no-local-version")
+    version = version.partition(".dev")[0]
+
+with open("README.md", "r") as fh:
+    description = fh.read()
+
+setuptools.setup(
+    long_description=description,
+    long_description_content_type="text/markdown",
+    version=version
+)


### PR DESCRIPTION
Hello,
I updated the repository such that it can generate wheel files and CI/CD.

I just attached the generated wheel file
[iot_inspector-2.0.2-py3-none-any.zip](https://github.com/user-attachments/files/21202154/iot_inspector-2.0.2-py3-none-any.zip)

1. You can now create Wheel files

If you want to build this locally, run `python -m build --wheel` and check the `dist/` folder

2. I started some code on generating the wheel file via CI/CD with versioning enabled. I don't know if the automated versioning will work correctly, but I got the first steps for it, so we can get this going soon.

There is also a new test to check if we are compliant with ruff linting.
